### PR TITLE
docs: add safe upgrade guidance (dry-run, wait/timeout, atomic)

### DIFF
--- a/content/en/docs/intro/CheatSheet.md
+++ b/content/en/docs/intro/CheatSheet.md
@@ -74,6 +74,29 @@ helm rollback <release> <revision>                        # Roll back a release 
 helm rollback <release> <revision>  --cleanup-on-fail     # Allow deletion of new resources created in this rollback when rollback fails
 ``` 
 ------------------------------------------------------------------------------------------------------------------------------------------------
+
+### Upgrade safely: dry-run, wait, timeout, and atomic rollback
+
+Before applying changes to a live release, it’s a good idea to simulate the upgrade and control how Helm waits for your workloads to become Ready.
+
+**1) Preview the upgrade**
+```bash
+helm upgrade my-release ./chart \
+  --dry-run --debug
+``` 
+------------------------------------------------------------------------------------------------------------------------------------------------
+
+**2) Perform a guarded upgrade**
+```bash
+helm upgrade my-release ./chart \
+  --install \
+  --wait \
+  --timeout 5m \
+  --atomic
+
+``` 
+------------------------------------------------------------------------------------------------------------------------------------------------
+
 ### List, Add, Remove, and Update Repositories
 
 ```bash


### PR DESCRIPTION
This PR adds a concise, task-focused subsection on performing safe Helm upgrades.

**What’s included**
- `helm upgrade --dry-run --debug` preview
- Explanation of `--wait` + `--timeout`
- Explanation of `--atomic` for automatic rollback on failure
- A copy/paste guarded upgrade example using `--install`
- Brief note about viewing diffs prior to upgrade (community diff plugin)

Rationale: Many users learn Helm from quick-start pages and the Cheat Sheet. This section gives them practical, production-friendly defaults and explains common flags that prevent partial or failed rollouts.

(Docs repo: helm/helm-www)
